### PR TITLE
node-gyp should be a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
   },
   "main": "./sse4_crc32",
   "dependencies": {
-    "node-gyp": "^1.0.2",
     "bindings": "~1.2.1",
     "nan": "^1.7.0"
   },
   "devDependencies": {
+    "node-gyp": "^1.0.2",
     "mocha": ">=2.1.0",
     "chai": ">=2.0.0",
     "crc32": ">=0.2.1"


### PR DESCRIPTION
When installing `crc32` I pull down all of node gyp when it's not needed.

It's only used in the Makefile for developer convenience when working on it locally so it should be a dev dependency like mocha is.