### PR TITLE
Fix to use SSE 4.2 Intrinsics header

### DIFF
--- a/src/crc32c_sse42.cpp
+++ b/src/crc32c_sse42.cpp
@@ -10,7 +10,7 @@
  * @author Anand Suresh <anandsuresh@gmail.com>
  */
 
-#include <smmintrin.h>
+#include <nmmintrin.h>
 
 #include "crc32c.h"
 


### PR DESCRIPTION
As @kkoopa pointed out, `smmintrin.h` is for use with SSE v4.1. `nmmintrin.h` is the correct header for use with SSE v4.2.

Not sure how it worked with the incorrect header for so long. Might be a point of differentiation between Windows and the rest.