### PR TITLE
Use newer NAN

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "sse4.2",
     "error detection"
   ],
-  "version": "5.1.0",
+  "version": "5.1.1",
   "author": "Anand Suresh <anandsuresh@gmail.com> (https://github.com/anandsuresh)",
   "license": "MIT",
   "repository": {
@@ -26,7 +26,7 @@
   "main": "./sse4_crc32",
   "dependencies": {
     "bindings": "~1.2.1",
-    "nan": "^2.0.0"
+    "nan": "^2.3.5"
   },
   "devDependencies": {
     "node-gyp": "^3.3.1",


### PR DESCRIPTION
The build fails with nan <2.2.0. With the flat dependency tree in npm 3, if a peer specifies an earlier version that still matches ^2.0.0 (e.g. 2.0.9), then sse4_crc32 will use that and fail. (If there are no peers, then npm will install the latest.)

These are the changes from nan 2.2 that are required:
https://github.com/nodejs/nan/compare/820a228...eca212b#diff-558c37be49a47656e3ff41806c24bd33R601